### PR TITLE
Compatibility redmine 6

### DIFF
--- a/app/controllers/workflow_permissions_api_controller.rb
+++ b/app/controllers/workflow_permissions_api_controller.rb
@@ -1,6 +1,6 @@
 class WorkflowPermissionsApiController < ApplicationController
 
-  before_filter :require_login
+  before_action :require_login
   accept_api_auth :index
 
   def index

--- a/app/controllers/workflow_transitions_api_controller.rb
+++ b/app/controllers/workflow_transitions_api_controller.rb
@@ -1,6 +1,6 @@
 class WorkflowTransitionsApiController < ApplicationController
 
-  before_filter :require_login
+  before_action :require_login
   accept_api_auth :index
 
   def index

--- a/app/views/workflow_permissions_api/index.api.rsb
+++ b/app/views/workflow_permissions_api/index.api.rsb
@@ -21,6 +21,18 @@ api.permissions do
               end
             end
           end
+          if custom_field.is_a?(IssueCustomField)
+            api.array :trackers do
+                custom_field.trackers.each do |tracker|
+                    api.tracker :id => tracker.id, :name => tracker.name
+                end
+            end
+          end
+          api.array :roles do
+            custom_field.roles.each do |role|
+              api.role :id => role.id, :name => role.name
+            end
+          end
           api.regexp custom_field.regexp
           api.min_length custom_field.min_length
           api.max_length custom_field.max_length


### PR DESCRIPTION
Replace `before_filter` with `before_action` in API controllers to align with Rails 5+ syntax.